### PR TITLE
Restore floathex parsing support for explicit '+' expo sign

### DIFF
--- a/BiNums.cpp
+++ b/BiNums.cpp
@@ -1599,6 +1599,7 @@ std::string_view GetIdentifier(std::string_view s)
             || (ch >= 'a' && ch <= 'z')
             || (ch == '.')
             || (ch == '-')
+            || (ch == '+')
             || (ch == '_');
     };
 


### PR DESCRIPTION
The floating-point literal representation supports explicit exponent signs, if given.  Support for '+' was okay prior to
cc95b95a7e3ebf0e1b48404b791b676b12d2bc72 changes.